### PR TITLE
project_id should be String to support ErrBit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn double_number(number_str: &str) -> Result<i32, ParseIntError> {
 
 fn main() {
     let airbrake = airbrake::configure(|config| {
-        config.project_id = 113743;
+        config.project_id = "113743".to_owned();
         config.project_key = "81bbff95d52f8856c770bb39e827f3f6".to_owned();
     });
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 #[derive(Debug)]
 pub struct Config {
-    pub project_id: u32,
+    pub project_id: String,
     pub project_key: String,
     pub host: String,
 }
@@ -8,7 +8,7 @@ pub struct Config {
 impl Config {
     pub fn new() -> Config {
         Config {
-            project_id: 0,
+            project_id: "0".to_owned(),
             project_key: "0".to_owned(),
             host: "https://airbrake.io".to_owned(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! fn main() {
 //!     let airbrake = airbrake::configure(|config| {
-//!         config.project_id = 113743;
+//!         config.project_id = "113743".to_owned();
 //!         config.project_key = "81bbff95d52f8856c770bb39e827f3f6".to_owned();
 //!     });
 //!
@@ -60,7 +60,7 @@ use config::Config;
 ///
 /// ```
 /// let airbrake = airbrake::configure(|config| {
-///     config.project_id = 113743;
+///     config.project_id = "113743".to_owned();
 ///     config.project_key = "81bbff95d52f8856c770bb39e827f3f6".to_owned();
 /// });
 pub fn configure<F>(configurator: F) -> Notifier


### PR DESCRIPTION
Changing project_id type to String so the lib can be used to report to ErrBit server where the project_id-s are hashes, not numbers.
