### PR TITLE
update endpoint for notifier and docs refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ let mut airbrake = airbrake::configure(|config| {
 
 ### host
 
-By default, it is set to `https://airbrake.io`. A `host` is a web address
+By default, it is set to `https://app.airbrake.io`. A `host` is a web address
 containing a scheme ("http" or "https"), a host and a port. You can omit the
 port (80 will be assumed).
 
@@ -151,7 +151,7 @@ airbrake.notify(std::io::Error::last_os_error());
 ```
 
 [airbrake.io]: https://airbrake.io
-[notice-v3]: https://airbrake.io/docs/#create-notice-v3
+[notice-v3]: https://docs.airbrake.io/docs/#create-notice-v3
 [env_logger]: https://crates.io/crates/env_logger
 [project-idkey]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/project-id-key.png
 [stderror]: https://doc.rust-lang.org/std/error

--- a/roadmap.md
+++ b/roadmap.md
@@ -64,7 +64,7 @@ Git flow, as described here typically has a `develop` and a `master` branch, tho
   - [x] ~~Circuit breaker~~ defer implementation to users
 
 - Sprint 3: Notify features
-  - [ ] Feature parity with [official API](https://airbrake.io/docs/api/#create-notice-v3) (super close to done, just need to verify I haven't missed anything)
+  - [ ] Feature parity with [official API](https://docs.airbrake.io/docs/api/#create-notice-v3) (super close to done, just need to verify I haven't missed anything)
   - [x] Notify on panic (Technically done and working, but could use some additional cleanup)
   - [x] Support [custom parameters](https://github.com/airbrake/pybrake#adding-custom-params)
   - [x] Severity
@@ -77,9 +77,9 @@ Git flow, as described here typically has a `develop` and a `master` branch, tho
 - Update roadmap
 
 - Sprint 4: Performance Monitoring
-  - [ ] [Route Performance](https://airbrake.io/docs/api/#route-performance-endpoint)
-  - [ ] [Routes Breakdown](https://airbrake.io/docs/api/#routes-breakdown-endpoint)
-  - [ ] [Database Query Stats](https://airbrake.io/docs/api/#database-query-stats)
+  - [ ] [Route Performance](https://docs.airbrake.io/docs/api/#route-performance-endpoint)
+  - [ ] [Routes Breakdown](https://docs.airbrake.io/docs/api/#routes-breakdown-endpoint)
+  - [ ] [Database Query Stats](https://docs.airbrake.io/docs/api/#database-query-stats)
 
 - Possible 0.4.0 release candidate
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use crate::NoticeBuilder;
 use crate::NoticeError;
 use crate::{Context, ContextBuilder, ContextProperties};
 
-const DEFAULT_HOSTNAME: &str = "https://airbrake.io";
+const DEFAULT_HOSTNAME: &str = "https://app.airbrake.io";
 const ENV_VAR_PROJECT_ID: &str = "AIRBRAKE_PROJECT_ID";
 const ENV_VAR_PROJECT_KEY: &str = "AIRBRAKE_API_KEY";
 const ENV_VAR_HOST: &str = "AIRBRAKE_HOST";
@@ -367,7 +367,7 @@ mod builder_tests {
             .project_key("bar")
             .build();
         assert_eq!(
-            "https://airbrake.io/api/v3/projects/foo/notices?key=bar",
+            "https://app.airbrake.io/api/v3/projects/foo/notices?key=bar",
             client.unwrap().endpoint_uri()
         );
     }
@@ -384,11 +384,11 @@ mod builder_tests {
             .project_key(project_key)
             .build();
         assert_eq!(
-            "https://airbrake.io/api/v3/projects/foo/notices?key=bar",
+            "https://app.airbrake.io/api/v3/projects/foo/notices?key=bar",
             client1.unwrap().endpoint_uri()
         );
         assert_eq!(
-            "https://airbrake.io/api/v3/projects/foo/notices?key=bar",
+            "https://app.airbrake.io/api/v3/projects/foo/notices?key=bar",
             client2.unwrap().endpoint_uri()
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!
 //! ### host
 //!
-//! By default, it is set to `https://airbrake.io`. A `host` is a web address
+//! By default, it is set to `https://app.airbrake.io`. A `host` is a web address
 //! containing a scheme ("http" or "https"), a host and a port. You can omit the
 //! port (80 will be assumed).
 //!
@@ -160,7 +160,7 @@
 //! ```
 //!
 //! [airbrake.io]: https://airbrake.io
-//! [notice-v3]: https://airbrake.io/docs/#create-notice-v3
+//! [notice-v3]: https://docs.airbrake.io/docs/#create-notice-v3
 //! [env_logger]: https://crates.io/crates/env_logger
 //! [project-idkey]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/project-id-key.png
 //! [stderror]: https://doc.rust-lang.org/std/error


### PR DESCRIPTION
Update notifier to app.airbrake.io
Update docs reference to docs.airbrake.io 

app.airbrake.io is a new change in airbrake for notifier ingestion and soon will be enforced as the defacto endpoint to hit for notifiers. 

docs.airbrake.io is the direct link to the api docs.